### PR TITLE
Fix signal generation after timeframe update

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -193,6 +193,9 @@ export function updateBitcoinChart(ohlcData: OHLCDataPoint[], timeframe: Timefra
         volume: point.volume
     }));
 
+    // Update global candle data so mock signals align with the current timeframe
+    (window as any).__candleData = chartData;
+
     candlestickSeries.data.setAll(chartData);
     
     if (chartData.length > 0) {


### PR DESCRIPTION
## Summary
- update global candle data when updating the Bitcoin chart

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'lightweight-charts')*

------
https://chatgpt.com/codex/tasks/task_b_685acb1cd3bc832587e914d56fbe8f95