### PR TITLE
Fix signal line visibility

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -193,6 +193,9 @@ export function updateBitcoinChart(ohlcData: OHLCDataPoint[], timeframe: Timefra
         volume: point.volume
     }));
 
+    // Update global candle data so mock signals align with the current timeframe
+    (window as any).__candleData = chartData;
+
     candlestickSeries.data.setAll(chartData);
     
     if (chartData.length > 0) {
@@ -289,17 +292,24 @@ export function addTradingSignals(signals: TradingSignal[], offsetRatio: number 
     signalSeries.data.setAll(signalData);
 
     signalSeries.set("visible", true);
-    signalSeries.set("stroke", am5.color("#fff")); // Невидимая линия
+    // Hide the line that connects signal markers
+    signalSeries.strokes.template.setAll({ strokeOpacity: 0 });
 
     signalSeries.bullets.push(() => {
         const label = am5.Label.new(btcChart!, {
             text: "{signal}",
-            fontSize: 6,
+            fontSize: 10,
             fontWeight: "bold",
             centerX: am5.p50,
             centerY: am5.p50,
             populateText: true,
             tooltipText: "{signal} signal at {date}\nPrice: {valueY}"
+        });
+
+        label.adapters.add("text", (text, target) => {
+            const dataItem = target.dataItem as any;
+            const value = dataItem?.dataContext?.signal;
+            return value ? value.toUpperCase() : text;
         });
 
         label.adapters.add("fill", () => am5.color("#fff"));
@@ -310,15 +320,15 @@ export function addTradingSignals(signals: TradingSignal[], offsetRatio: number 
                     fill: am5.color("#00ff00"),
                     stroke: am5.color("#00ff00"),
                     strokeOpacity: 0,
-                    width: 12,
-                    height: 12
+                    width: 20,
+                    height: 20
                 })
                 : am5.Rectangle.new(btcChart!, {
                     fill: am5.color("#ff0000"),
                     stroke: am5.color("#ff0000"),
                     strokeOpacity: 0,
-                    width: 12,
-                    height: 12
+                    width: 20,
+                    height: 20
                 });
         });
 

--- a/src/dataService.ts
+++ b/src/dataService.ts
@@ -24,7 +24,6 @@ export type Timeframe = '15m' | '1h' | '4h' | '12h' | '1d';
 
 // Calculate milliseconds for each timeframe
 function getTimeframeMs(timeframe: Timeframe): number {
-  const now = new Date();
   const msMap: Record<Timeframe, number> = {
     '15m': 15 * 60 * 1000,
     '1h': 60 * 60 * 1000,

--- a/src/signalsService.ts
+++ b/src/signalsService.ts
@@ -4,8 +4,8 @@ import { TradingSignal } from './types/signals';
 import { Timeframe } from './dataService';
 
 export async function fetchTradingSignals(
-  ticker: string = 'BTC', 
-  timeframe: Timeframe
+  _ticker: string = 'BTC',
+  _timeframe: Timeframe
 ): Promise<TradingSignal[]> {
   try {
     // Временное решение - используем mock-данные


### PR DESCRIPTION
## Summary
- hide the line connecting signal markers
- display `BUY` and `SELL` text on signal markers

## Testing
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_b_685acb1cd3bc832587e914d56fbe8f95